### PR TITLE
Install cmdmodel*.rb and model*.yaml files

### DIFF
--- a/ubuntu/debian/libignition-gazebo-dev.install
+++ b/ubuntu/debian/libignition-gazebo-dev.install
@@ -4,4 +4,6 @@ usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-gazebo*/*
 usr/share/ignition/ignition-gazebo[0-99]/ignition-gazebo[0-99].tag.xml
 usr/share/ignition/gazebo[0-99].yaml
+usr/share/ignition/model[0-99].yaml
 usr/lib/ruby/ignition/cmdgazebo[0-99].rb
+usr/lib/ruby/ignition/cmdmodel[0-99].rb


### PR DESCRIPTION
Fix unstable build:

~~~
dh_missing --list-missing
dh_missing: warning: usr/share/ignition/model6.yaml exists in debian/tmp but is not installed to anywhere
dh_missing: warning: usr/lib/ruby/ignition/cmdmodel6.rb exists in debian/tmp but is not installed to anywhere
~~~

* [![Build Status](https://build.osrfoundation.org/buildStatus/icon?job=ign-gazebo6-debbuilder&build=251)](https://build.osrfoundation.org/job/ign-gazebo6-debbuilder/251/) https://build.osrfoundation.org/job/ign-gazebo6-debbuilder/251/