### PR TITLE
Remove doxygen from packaging due to segfaults

### DIFF
--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -27,6 +27,8 @@ Build-Depends: cmake,
                libsdformat12-dev (>= 12.3.0),
                python3-dev,
                python3-pybind11
+# doxygen and grapviz are excluded per bug:
+# https://github.com/ignitionrobotics/ign-gazebo/issues/1409
 Vcs-Browser: https://github.com/ignitionrobotics/ignition-gazebo
 Vcs-Git: https://github.com/ignition-release/ign-gazebo6-release
 Standards-Version: 4.5.1

--- a/ubuntu/debian/control
+++ b/ubuntu/debian/control
@@ -3,8 +3,6 @@ Maintainer: Jose Luis Rivero <jrivero@osrfoundation.org>
 Section: science
 Priority: optional
 Build-Depends: cmake,
-               doxygen,
-               graphviz,
                pkg-config,
                debhelper (>= 11),
                dh-python,

--- a/ubuntu/debian/debian_copyright_2022
+++ b/ubuntu/debian/debian_copyright_2022
@@ -2,15 +2,6 @@ Format: https://www.debian.org/doc/packaging-manuals/copyright-format/1.0/
 Upstream-Name: ignition-gazebo
 Upstream-Contact: https://github.com/ignitionrobotics/ign-gazebo/issues
 Source: https://github.com/ignitionrobotics/ign-gazebo
-Comment: All the test *.dae *.obj files are non-free: CC NonCommercial
-Files-Excluded: .github
-                NEWS
-                codecov.yml
-                test/gtest
-                test/media/*.dae
-                test/worlds/models/building_L1/meshes
-                test/worlds/models/scheme_resource_uri/meshes
-                test/worlds/models/mesh_with_submeshes/meshes
 
 Files: *
 Copyright: 2012-2021, Open Source Robotics Foundation

--- a/ubuntu/debian/libignition-gazebo-dev.install
+++ b/ubuntu/debian/libignition-gazebo-dev.install
@@ -2,7 +2,6 @@ usr/include/*
 usr/lib/*/*.so
 usr/lib/*/pkgconfig/*.pc
 usr/lib/*/cmake/ignition-gazebo*/*
-usr/share/ignition/ignition-gazebo[0-99]/ignition-gazebo[0-99].tag.xml
 usr/share/ignition/gazebo[0-99].yaml
 usr/share/ignition/model[0-99].yaml
 usr/lib/ruby/ignition/cmdgazebo[0-99].rb


### PR DESCRIPTION
Packaging fails to run doxygen properly, see https://github.com/ignitionrobotics/ign-gazebo/issues/1409.

In this same PR, an unrelated clean-up to make QA happy 9a462d902f421d5c317651ae48d9b4324a8f1b93
